### PR TITLE
✨ NEW: Fish implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/
 .coverage
 .tox
 *.log
+.history/*
+.aiida_projects/
+.vscode/


### PR DESCRIPTION
Added `ShellGenerator` class to streamline different shell commands. Currently, it takes the `shell_str` as instance variable to select the appropriate code, while `shell_str` and `env_file_path` are populated in the `.format()` call when the shell commands are returned. This still seems a bit clunky, any ideas how to improve that?

Added `from_env_file` classmethod to `ProjectConfig` to populate config instance from .env file. Renamed set_key/get_key to write_key/read_key.

Instantiation of `ProjectConfig` passing default arguments of `aiida_venv_dir` and `aiida_project_dir`, as setting inside ProjectConfig did not seem to have intended effect?