### PR TITLE
Adding `cda` tab completion and `list` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ or simply open a new terminal.
 
 This will also add the `cda` function to your shell startup file, so you can easily switch projects.
 Note that you'll have to source your e.g. `.zshrc` file for this function to be accessible!
+In order to activate tab-completion, you'll have to run `aiida-project --install-completion` and restart the terminal afterwards.
 
 ### `create`
 
@@ -65,6 +66,16 @@ You can then activate the project using the `cda` command described above:
 
 ```console
 cda firstproject
+```
+The `cda` command supports tab-completion and lists the available projects. Moreover, you can use the `list` command to show all available projects grouped by the corresponding environment (either conda or venv).
+```console
+(firstproject) ~$ aiida-project list
+The following projects are available:
+
+  venv
+    firstproject
+    hp_tests
+
 ```
 
 Next to activating the Python virtual environment, this will also change the directory to the one for the project.


### PR DESCRIPTION
This would close #11.
In addition to the `list` command, I also added tab completion for the `cda` command to suggest the available projects. 

The format of the `list` command can probably be adjusted. Moreover, one could think of adding additional information about the projects (e.g. a description attribute, etc.).

I was also thinking that it might be useful to add another command to show the configuration of `aiida-project`. E.g. one could list the project path etc., so something similar to `verdi status` in `aiida-core`.