### PR TITLE
♻️🐛 Refactor `project` subpackage

### DIFF
--- a/aiida_project/project/__init__.py
+++ b/aiida_project/project/__init__.py
@@ -1,20 +1,7 @@
-from .base import EngineType, ProjectDict, BaseProject
-from .venv import VenvProject
-from .conda import CondaProject
-from typing import Type
+from .core import EngineType, ProjectDict, load_project_class
 
 __all__ = [
     "EngineType",
-    "BaseProject",
-    "VenvProject",
+    "load_project_class",
     "ProjectDict",
 ]
-
-
-def load_project_class(engine_type: str) -> Type[BaseProject]:
-    """Load the project class corresponding the engine type."""
-    engine_project_dict = {
-        "venv": VenvProject,
-        "conda": CondaProject,
-    }
-    return engine_project_dict[engine_type]

--- a/aiida_project/project/core.py
+++ b/aiida_project/project/core.py
@@ -1,0 +1,50 @@
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Type, Union
+
+from ..config import ProjectConfig
+from .base import BaseProject
+from .conda import CondaProject
+from .venv import VenvProject
+
+
+def load_project_class(engine_type: str) -> Type[BaseProject]:
+    """Load the project class corresponding the engine type."""
+    engine_project_dict = {
+        "venv": VenvProject,
+        "conda": CondaProject,
+    }
+    return engine_project_dict[engine_type]
+
+
+class EngineType(str, Enum):
+    venv = "venv"
+    conda = "conda"
+
+
+class ProjectDict:
+    _projects_path = Path(ProjectConfig().aiida_project_dir, ".aiida_projects")
+
+    def __init__(self):
+        if not self._projects_path.exists():
+            self._projects_path.joinpath("venv").mkdir(parents=True, exist_ok=True)
+            self._projects_path.joinpath("conda").mkdir(parents=True, exist_ok=True)
+
+    @property
+    def projects(self) -> Dict[str, BaseProject]:
+        projects = {}
+        for project_file in self._projects_path.glob("**/*.json"):
+            engine = load_project_class(str(project_file.parent.name))
+            project = engine.parse_file(project_file)
+            projects[project.name] = project
+        return projects
+
+    def add_project(self, project: BaseProject) -> None:
+        """Add a project to the configuration files."""
+        with Path(self._projects_path, project.engine, f"{project.name}.json").open("w") as handle:
+            handle.write(project.json())
+
+    def remove_project(self, project: Union[str, BaseProject]) -> None:
+        """Remove a project from the configuration files."""
+        project = self.projects[project] if isinstance(project, str) else project
+        Path(self._projects_path, project.engine, f"{project.name}.json").unlink()


### PR DESCRIPTION
While providing `fish` support in d6a299c, we unfortunately introduced a bug: `ProjectDict` was moved into the `base.py` module, but `load_project_class` was not imported here and is used by one of the methods of `ProjectDict`.

A straightforward fix would be either import `load_project_class` in `base.py` or move it into the module as well, but both these options would lead to circular imports. Since the `base.py` module is really only for defining the `BaseProject` abstract class, `ProjectDict`, `load_project_class` and `EngineType` are probably more at home in a seprate `core.py` module.