### PR TITLE
Fix init_lines string of zsh/bash not proper paramatized

### DIFF
--- a/aiida_project/data/shell_fields.yaml
+++ b/aiida_project/data/shell_fields.yaml
@@ -1,11 +1,11 @@
 bash:
   config_file: .bashrc
   init_lines: &bash_init_lines |
-    export $(grep -v '^#' {env_file} | xargs)
-    cda () {
+    export $(grep -v '^#' {env_file_path} | xargs)
+    cda () {{
       source "$aiida_venv_dir/$1/bin/activate"
       cd "$aiida_project_dir/$1"
-    }
+    }}
   activate: |
     export AIIDA_PATH={env_file_path}
     eval "$(_VERDI_COMPLETE=bash_source verdi)"


### PR DESCRIPTION
fixes #19 

I using zsh, the init_lines template still use `env_file`, and lead to `KeyError: 'env_file'`.