### PR TITLE
Implement uv backend :rocket:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ jobs:
 
   test:
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.13']
+
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -23,7 +28,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         version: 0.8.21
-        python-version: 3.13
+        python-version: ${{ matrix.python-version }}
         activate-environment: true
 
     - name: Install aiida-project as an app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Create
       run: aiida-project create testproject
 
+    - name: Create with additional plugins
+      run: 'aiida-project create testproject2 -p aiida-cp2k -p https://github.com/aiidateam/aiida-quantumespresso'
+
       # NOTE: The cda bash function does not seem to work in GitHub runners so we execute it manually
     - name: cda
       run: |
@@ -50,4 +53,8 @@ jobs:
           ls -lrt
 
     - name: Destroy
-      run: aiida-project destroy --force testproject
+      run: |
+        aiida-project destroy --force testproject
+        export $(grep -v '^#' ~/.aiida_project.env | xargs)
+        if [[ -d "$aiida_project_dir/testproject" ]]; then echo "Project destruction incomplete!"; exit 1; fi
+        if [[ -d "$aiida_venv_dir/testproject" ]]; then echo "Project venv not destroyed!"; exit 1; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,10 @@ jobs:
       run: |
           cat ~/.aiida_project.env
           export $(grep -v '^#' ~/.aiida_project.env | xargs)
-          source "$aiida_venv_dir/testproject/bin/activate"
-          cd "$aiida_project_dir/testproject" && pwd
+          source "$aiida_venv_dir/testproject2/bin/activate"
+          cd "$aiida_project_dir/testproject2" && pwd
           ls -lrt
+          uv pip list
 
     - name: Destroy
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,18 @@ jobs:
       run: uv tool install .
 
     - name: Init
-      run: aiida-project init --shell bash
+      run: |
+        aiida-project init --shell bash
+        cat ~/.bashrc
+        source ~/.bashrc && cda testproject
 
     - name: Create
       run: aiida-project create testproject
 
     - name: cda
-      run: source ~/.bashrc && cda testproject
+      run: |
+        cat ~/.bashrc
+        source ~/.bashrc && cda testproject
 
     - name: Destroy
       run: aiida-project destroy testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+
+  pre-commit:
+
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: 0.8.21
+        python-version: 3.13
+        activate-environment: true
+
+    - name: Install aiida-project as an app
+      run: uv tool install .
+
+    - name: Create a test project
+      run: aiida-project create testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       run: aiida-project init --shell bash
 
     - name: Create
-      run: aiida-project create testproject && cda testproject
+      run: aiida-project create testproject
 
     - name: cda
       run: source ~/.bashrc && cda testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-24.04, macos-15]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
           cd "$aiida_project_dir/testproject"
 
     - name: Destroy
-      run: aiida-project destroy testproject
+      run: aiida-project destroy --force testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        os: [ubuntu-24.04, macos-15]
 
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
 
-  pre-commit:
+  test:
 
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -29,5 +29,8 @@ jobs:
     - name: Install aiida-project as an app
       run: uv tool install .
 
-    - name: Create a test project
+    - name: Init
+      run: aiida-project init --shell bash
+
+    - name: Create
       run: aiida-project create testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,7 @@ jobs:
       run: aiida-project init --shell bash
 
     - name: Create
-      run: aiida-project create testproject
+      run: aiida-project create testproject && cda testproject
+
+    - name: Destroy
+      run: aiida-project destroy testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,8 @@ jobs:
     - name: Create
       run: aiida-project create testproject && cda testproject
 
+    - name: cda
+      run: source ~/.bashrc && cda testproject
+
     - name: Destroy
       run: aiida-project destroy testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,14 +40,14 @@ jobs:
     - name: Create
       run: aiida-project create testproject
 
+      # NOTE: The cda bash function does not seem to work in GitHub runners so we execute it manually
     - name: cda
       run: |
-          # NOTE: The cda bash function does not seem to work in GitHub runners so we execute it manually
-          #source ~/.bashrc && cda testproject
           cat ~/.aiida_project.env
           export $(grep -v '^#' ~/.aiida_project.env | xargs)
           source "$aiida_venv_dir/testproject/bin/activate"
-          cd "$aiida_project_dir/testproject"
+          cd "$aiida_project_dir/testproject" && pwd
+          ls -lrt
 
     - name: Destroy
       run: aiida-project destroy --force testproject

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,18 +35,19 @@ jobs:
       run: uv tool install .
 
     - name: Init
-      run: |
-        aiida-project init --shell bash
-        cat ~/.bashrc
-        source ~/.bashrc && cda testproject
+      run: aiida-project init --shell bash
 
     - name: Create
       run: aiida-project create testproject
 
     - name: cda
       run: |
-        cat ~/.bashrc
-        source ~/.bashrc && cda testproject
+          # NOTE: The cda bash function does not seem to work in GitHub runners so we execute it manually
+          #source ~/.bashrc && cda testproject
+          cat ~/.aiida_project.env
+          export $(grep -v '^#' ~/.aiida_project.env | xargs)
+          source "$aiida_venv_dir/testproject/bin/activate"
+          cd "$aiida_project_dir/testproject"
 
     - name: Destroy
       run: aiida-project destroy testproject

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -96,18 +96,17 @@ def create(
 
     config = ProjectConfig()
     if config.is_not_initialised():
-        return
+        sys.exit(1)
 
     venv_path = config.aiida_venv_dir / Path(name)
     project_path = config.aiida_project_dir / Path(name)
 
     # Temporarily block `conda` engines until we provide support again
     if engine is EngineType.conda:
-        print(
+        exit(
             "[bold red]Error:[/bold red] The `conda` engine is currently disabled until we restore "
             "support."
         )
-        return
 
     project = load_project_class(engine.value)(
         name=name,
@@ -124,8 +123,7 @@ def create(
             if python_which is None:
                 python_which = shutil.which(f"python{python}")
             if python_which is None:
-                print("[bold red]Error:[/bold red] Could not resolve path to Python binary.")
-                return
+                exit("[bold red]Error:[/bold red] Could not resolve path to Python binary.")
             else:
                 python_path = Path(python_which)
 
@@ -174,15 +172,14 @@ def destroy(
     from ..project import ProjectDict
 
     if ProjectConfig().is_not_initialised():
-        return
+        sys.exit(1)
 
     project_dict = ProjectDict()
 
     try:
         project = project_dict.projects[name]
     except KeyError:
-        print(f"[bold red]Error:[/bold red] No project with name {name} found!")
-        return
+        exit(f"[bold red]Error:[/bold red] No project with name {name} found!")
 
     if not force:
         typer.confirm(

--- a/aiida_project/project/core.py
+++ b/aiida_project/project/core.py
@@ -5,13 +5,14 @@ from typing import Dict, Type, Union
 from ..config import ProjectConfig
 from .base import BaseProject
 from .conda import CondaProject
-from .venv import VenvProject
+from .venv import VenvProject, UvVenvProject
 
 
 def load_project_class(engine_type: str) -> Type[BaseProject]:
     """Load the project class corresponding the engine type."""
     engine_project_dict = {
         "venv": VenvProject,
+        "uv": UvVenvProject,
         "conda": CondaProject,
     }
     return engine_project_dict[engine_type]
@@ -19,6 +20,7 @@ def load_project_class(engine_type: str) -> Type[BaseProject]:
 
 class EngineType(str, Enum):
     venv = "venv"
+    uv = "uv"
     conda = "conda"
 
 
@@ -29,6 +31,9 @@ class ProjectDict:
         if not self._projects_path.exists():
             self._projects_path.joinpath("venv").mkdir(parents=True, exist_ok=True)
             self._projects_path.joinpath("conda").mkdir(parents=True, exist_ok=True)
+        uv_path = self._projects_path / "uv"
+        if not uv_path.exists():
+            uv_path.mkdir(parents=True, exist_ok=True)
 
     @property
     def projects(self) -> Dict[str, BaseProject]:

--- a/aiida_project/project/core.py
+++ b/aiida_project/project/core.py
@@ -5,14 +5,13 @@ from typing import Dict, Type, Union
 from ..config import ProjectConfig
 from .base import BaseProject
 from .conda import CondaProject
-from .venv import VenvProject, UvVenvProject
+from .venv import VenvProject
 
 
 def load_project_class(engine_type: str) -> Type[BaseProject]:
     """Load the project class corresponding the engine type."""
     engine_project_dict = {
         "venv": VenvProject,
-        "uv": UvVenvProject,
         "conda": CondaProject,
     }
     return engine_project_dict[engine_type]
@@ -20,7 +19,6 @@ def load_project_class(engine_type: str) -> Type[BaseProject]:
 
 class EngineType(str, Enum):
     venv = "venv"
-    uv = "uv"
     conda = "conda"
 
 
@@ -31,9 +29,6 @@ class ProjectDict:
         if not self._projects_path.exists():
             self._projects_path.joinpath("venv").mkdir(parents=True, exist_ok=True)
             self._projects_path.joinpath("conda").mkdir(parents=True, exist_ok=True)
-        uv_path = self._projects_path / "uv"
-        if not uv_path.exists():
-            uv_path.mkdir(parents=True, exist_ok=True)
 
     @property
     def projects(self) -> Dict[str, BaseProject]:

--- a/aiida_project/project/venv.py
+++ b/aiida_project/project/venv.py
@@ -1,19 +1,18 @@
 import shutil
-import sys
 import subprocess
+import sys
 from pathlib import Path
 
 from aiida_project.config import ProjectConfig
 from aiida_project.project.base import BaseProject
-
-# uv should be installed in the same place as aiida-project itself
-UV = Path(sys.executable).parent / "uv"
 
 
 class VenvProject(BaseProject):
     """An AiiDA environment based on `venv`."""
 
     _engine = "venv"
+    # uv should be installed in the same place as aiida-project itself
+    _uv_path = (Path(sys.executable).parent / "uv").as_posix()
 
     shell_activate_mapping: dict = {
         "bash": "activate",
@@ -28,12 +27,19 @@ class VenvProject(BaseProject):
 
     def create(self, python_path: Path) -> None:
         super().create(python_path)
-        venv_command = [f"{python_path.resolve()}", "-m", "venv", "."]
         self.venv_path.mkdir(
             exist_ok=True,
             parents=True,
         )
-        subprocess.run(venv_command, cwd=self.venv_path, capture_output=True)
+        # TODO: uv by default clears the existing folder. Is that okay? Should we guard against it?
+        venv_command = [
+            self._uv_path,
+            "venv",
+            "-p",
+            f"{python_path.resolve()}",
+            str(self.venv_path),
+        ]
+        subprocess.run(venv_command, capture_output=True)
 
     def destroy(self):
         """Destroy the project."""
@@ -63,38 +69,19 @@ class VenvProject(BaseProject):
             )
 
     def install(self, package):
-        install_command = [Path(self.venv_path, "bin", "pip").as_posix(), "install", package]
-        subprocess.run(install_command, capture_output=True)
-
-    def install_local(self, path):
-        install_command = []
-        install_command.append(Path(self.venv_path, "bin", "pip")).as_posix()
-        install_command.extend(["install", "-e", path.as_posix()])
-        subprocess.run(install_command, cwd=self.project_path)
-
-
-class UvVenvProject(VenvProject):
-    """An AiiDA environment based on `venv` and `uv`."""
-
-    _engine = "uv"
-    uv_path = UV.as_posix()
-
-    def create(self, python_path: Path) -> None:
-        super().create(python_path)
-        self.venv_path.mkdir(
-            exist_ok=True,
-            parents=True,
-        )
-        venv_command = [self.uv_path, "venv", "-p", f"{python_path.resolve()}", str(self.venv_path)]
-        subprocess.run(venv_command, capture_output=True)
-
-    def install(self, package):
         python_path = Path(self.venv_path, "bin", "python").as_posix()
-        install_command = [self.uv_path,  "pip", "install", "-p", python_path, package]
+        install_command = [self._uv_path, "pip", "install", "-p", python_path, package]
         subprocess.run(install_command, capture_output=True)
 
     def install_local(self, path):
         python_path = Path(self.venv_path, "bin", "python").as_posix()
-        install_command = [self.uv_path, "-p", python_path]
-        install_command.extend(["pip", "install", "-e", path.as_posix()])
+        install_command = [
+            self._uv_path,
+            "pip",
+            "install",
+            "-p",
+            python_path,
+            "-e",
+            path.as_posix(),
+        ]
         subprocess.run(install_command, cwd=self.project_path)

--- a/aiida_project/project/venv.py
+++ b/aiida_project/project/venv.py
@@ -90,7 +90,7 @@ class UvVenvProject(VenvProject):
 
     def install(self, package):
         python_path = Path(self.venv_path, "bin", "python").as_posix()
-        install_command = [self.uv_path, "-p", python_path, "pip", "install", package]
+        install_command = [self.uv_path,  "pip", "install", "-p", python_path, package]
         subprocess.run(install_command, capture_output=True)
 
     def install_local(self, path):

--- a/aiida_project/project/venv.py
+++ b/aiida_project/project/venv.py
@@ -1,9 +1,13 @@
 import shutil
+import sys
 import subprocess
 from pathlib import Path
 
 from aiida_project.config import ProjectConfig
 from aiida_project.project.base import BaseProject
+
+# uv should be installed in the same place as aiida-project itself
+UV = Path(sys.executable).parent / "uv"
 
 
 class VenvProject(BaseProject):
@@ -73,10 +77,7 @@ class UvVenvProject(VenvProject):
     """An AiiDA environment based on `venv` and `uv`."""
 
     _engine = "uv"
-    # TODO: We can install uv as a dependency of aiida-project, but then we somehow need to get the path to it,
-    # In other words we need to introspect ourselves and find our bin directory maybe? Or do "python -m uv",
-    # but this needs to be our python!
-    # uv_path = ...
+    uv_path = UV.as_posix()
 
     def create(self, python_path: Path) -> None:
         super().create(python_path)
@@ -84,17 +85,16 @@ class UvVenvProject(VenvProject):
             exist_ok=True,
             parents=True,
         )
-        venv_command = ["uv", "venv", "-p", f"{python_path.resolve()}", str(self.venv_path)]
+        venv_command = [self.uv_path, "venv", "-p", f"{python_path.resolve()}", str(self.venv_path)]
         subprocess.run(venv_command, capture_output=True)
 
     def install(self, package):
-        # TODO: Should ensure "uv" executable exists
         python_path = Path(self.venv_path, "bin", "python").as_posix()
-        install_command = ["uv", "-p", python_path, "pip", "install", package]
+        install_command = [self.uv_path, "-p", python_path, "pip", "install", package]
         subprocess.run(install_command, capture_output=True)
 
     def install_local(self, path):
         python_path = Path(self.venv_path, "bin", "python").as_posix()
-        install_command = ["uv", "-p", python_path]
+        install_command = [self.uv_path, "-p", python_path]
         install_command.extend(["pip", "install", "-e", path.as_posix()])
         subprocess.run(install_command, cwd=self.project_path)

--- a/aiida_project/shell.py
+++ b/aiida_project/shell.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from importlib import resources
 from pathlib import Path
 
 import yaml
@@ -36,6 +35,11 @@ def load_shell(shell_str: str) -> Shell:
     """Load the project class corresponding the engine type."""
     from . import data
 
-    with (resources.files(data) / "shell_fields.yaml").open("r") as handle:
+    try:
+        from importlib.resources import files
+    except ImportError:
+        from importlib_resources import files
+
+    with (files(data) / "shell_fields.yaml").open("r") as handle:
         specs = yaml.safe_load(handle)
     return Shell(**specs[shell_str])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
   "typer[all]~=0.9",
   "pyyaml~=6.0",
   'eval-type-backport; python_version<"3.10"',
-  'importlib_resources; python_version<"3.9"'
-  "uv~=0.5",
+  'importlib_resources; python_version<"3.9"',
+  "uv~=0.8.20",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "pyyaml~=6.0",
   'eval-type-backport; python_version<"3.10"',
   'importlib_resources; python_version<"3.9"'
+  "uv~=0.5",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering"
 ]
 keywords = ["aiida", "workflows"]
@@ -31,6 +33,7 @@ dependencies = [
   "python-dotenv~=1.0",
   "typer[all]~=0.9",
   "pyyaml~=6.0",
+  'eval-type-backport; python_version<"3.10"',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "typer[all]~=0.9",
   "pyyaml~=6.0",
   'eval-type-backport; python_version<"3.10"',
+  'importlib_resources; python_version<"3.9"'
 ]
 
 [project.urls]


### PR DESCRIPTION
tl;dr with `uv` (and warm uv cache), **creating a new aiida project takes around 3 seconds** (unlike 30-40 seconds with pip). You can finally have a tagline "Create AiiDA project in a jiffy!"

~~After more testing I think it would be reasonable for this to be a new default, but would keep pip as a fallback option (we've been using `uv` in CI for a while and haven't had much issues).~~

Closes #27 