### PR TITLE
Update mypy and its configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,14 +39,18 @@ repos:
     hooks:
     - id: ruff
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+  # NOTE: mypy needs to be installed in the same environment as the package
+  # and all of its 3rd party dependencies.
+  # See https://jaredkhan.com/blog/mypy-pre-commit for detailed rationale.
+  - repo: local
     hooks:
     - id: mypy
-      args: [--config-file=pyproject.toml]
-      additional_dependencies:
-      - py
-      files: >
-        (?x)^(
-            aiida_project/.*py|
-        )$
+      name: mypy
+      entry: mypy
+      args: [--config-file=pyproject.toml, --pretty, ./aiida_project]
+      # Always analyze all files, since changes in one file can introduce errors
+      # in modules that depend on it.
+      pass_filenames: false
+      require_serial: true
+      language: python
+      types: [python]

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -36,11 +36,19 @@ def init(shell: Optional[ShellType] = None):
         shell_guess = os.environ.get("SHELL", "")
         detected_shell = shell_guess.split("/")[-1] if shell_guess else None
         prompt_message = "👋 Hello there! Which shell are you using?"
-        shell_str = prompt.Prompt.ask(
-            prompt=prompt_message,
-            choices=[shell_type.value for shell_type in ShellType],
-            default=detected_shell,
-        )
+        # NOTE: Passing `None` or '' as default bypasses the validation of valid choices,
+        # hence the ugly if-else.
+        if detected_shell is None:
+            shell_str = prompt.Prompt.ask(
+                prompt=prompt_message,
+                choices=[shell_type.value for shell_type in ShellType],
+            )
+        else:
+            shell_str = prompt.Prompt.ask(
+                prompt=prompt_message,
+                choices=[shell_type.value for shell_type in ShellType],
+                default=detected_shell,
+            )
 
     config.set_key("aiida_project_shell", shell_str)
     shellz = load_shell(shell_str)

--- a/aiida_project/project/core.py
+++ b/aiida_project/project/core.py
@@ -14,7 +14,7 @@ def load_project_class(engine_type: str) -> Type[BaseProject]:
         "venv": VenvProject,
         "conda": CondaProject,
     }
-    return engine_project_dict[engine_type]
+    return engine_project_dict[engine_type]  # type: ignore[return-value]
 
 
 class EngineType(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,21 +44,15 @@ aiida-project = "aiida_project.commands.main:app"
 [project.optional-dependencies]
 dev = [
   "pre-commit>=3.4",
+  "mypy~=1.18.1",
+  "types-pyyaml~=6.0",
 ]
+
+[tool.mypy]
+plugins = ['pydantic.mypy']
 
 [tool.black]
 line-length = 100
 
 [tool.ruff]
 line-length = 100
-
-[[tool.mypy.overrides]]
-module = [
-  "dotenv",
-  "pydantic",
-  "pydantic_settings",
-  "yaml",
-  "typer",
-  "rich"
-]
-ignore_missing_imports = true


### PR DESCRIPTION
See https://jaredkhan.com/blog/mypy-pre-commit for a detailed rationale of the mypy configuration. (the configuration introduced here roughly matches the one in aiida-core)

In the second  commit I fixed a small issue with the init command. mypy complained about passing `None` as a default argument to `Prompt.ask` method. It actually kinda worked at runtime, but it was not ideal, because if the user pressed enter without inputing the name of their shell, this would bypass validation and crash in the next step. Whereas what we would expect is the same thing that happens when the user enters an invalid shell --- the command will actually not continue and re-prompts. It seems that the only way for this to work correctly is two have two branches in the code, depending on whether we can provide a reasonable default (by autodetecting the shell) or not.