### PR TITLE
Pre-commit update

### DIFF
--- a/.github/workflows/update_changelog.py
+++ b/.github/workflows/update_changelog.py
@@ -1,5 +1,6 @@
 #!/bin/bash
 """Script for updating the `CHANGELOG.md` based on the commits since the latest release tag."""
+
 import re
 import subprocess
 from pathlib import Path

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -1,4 +1,5 @@
 """Validate that the version in the tag label matches the version of the package."""
+
 import argparse
 import ast
 from pathlib import Path
@@ -30,9 +31,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("GITHUB_REF", help="The GITHUB_REF environmental variable")
     args = parser.parse_args()
-    assert args.GITHUB_REF.startswith(
-        "refs/tags/v"
-    ), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
+    assert args.GITHUB_REF.startswith("refs/tags/v"), (
+        f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
+    )
     tag_version = args.GITHUB_REF[11:]
     package_version = get_version_from_module(
         Path("aiida_project/__init__.py").read_text(encoding="utf-8")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,26 +18,12 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.1
     hooks:
-    - id: pyupgrade
-      args: [--py37-plus]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    - id: black
-
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.252
-    hooks:
-    - id: ruff
+    - id: ruff-format
+    - id: ruff-check
+      args: [--fix, --exit-non-zero-on-fix]
 
   # NOTE: mypy needs to be installed in the same environment as the package
   # and all of its 3rd party dependencies.

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -3,11 +3,10 @@ import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Annotated, Optional
 
 import typer
 from rich import print, prompt
-from typing_extensions import Annotated
 
 from ..project import EngineType, load_project_class
 from ..shell import ShellType, load_shell
@@ -84,12 +83,12 @@ def init(shell: Optional[ShellType] = None):
 
 
 @app.command()
-def create(
+def create(  # noqa: PLR0912
     name: str,
     engine: EngineType = EngineType.venv,
     core_version: str = "latest",
     plugins: Annotated[
-        List[str], typer.Option("--plugin", "-p", help="Extra plugins to install.")
+        list[str], typer.Option("--plugin", "-p", help="Extra plugins to install.")
     ] = [],
     python: Annotated[
         Optional[str],

--- a/aiida_project/config.py
+++ b/aiida_project/config.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
 
 import dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -20,7 +21,7 @@ class ProjectConfig(BaseSettings):
 
     aiida_venv_dir: Path = Path(Path.home(), ".aiida_venvs")
     aiida_project_dir: Path = Path(Path.home(), "project")
-    aiida_default_python_path: Optional[Path] = None
+    aiida_default_python_path: Path | None = None
     aiida_project_structure: dict = DEFAULT_PROJECT_STRUCTURE
     aiida_project_shell: str = "bash"
     model_config = SettingsConfigDict(

--- a/aiida_project/project/__init__.py
+++ b/aiida_project/project/__init__.py
@@ -2,6 +2,6 @@ from .core import EngineType, ProjectDict, load_project_class
 
 __all__ = [
     "EngineType",
-    "load_project_class",
     "ProjectDict",
+    "load_project_class",
 ]

--- a/aiida_project/project/core.py
+++ b/aiida_project/project/core.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Type, Union
 
 from ..config import ProjectConfig
 from .base import BaseProject
@@ -8,7 +9,7 @@ from .conda import CondaProject
 from .venv import VenvProject
 
 
-def load_project_class(engine_type: str) -> Type[BaseProject]:
+def load_project_class(engine_type: str) -> type[BaseProject]:
     """Load the project class corresponding the engine type."""
     engine_project_dict = {
         "venv": VenvProject,
@@ -31,7 +32,7 @@ class ProjectDict:
             self._projects_path.joinpath("conda").mkdir(parents=True, exist_ok=True)
 
     @property
-    def projects(self) -> Dict[str, BaseProject]:
+    def projects(self) -> dict[str, BaseProject]:
         projects = {}
         for project_file in self._projects_path.glob("**/*.json"):
             engine = load_project_class(str(project_file.parent.name))
@@ -44,7 +45,7 @@ class ProjectDict:
         with Path(self._projects_path, project.engine, f"{project.name}.json").open("w") as handle:
             handle.write(project.json())
 
-    def remove_project(self, project: Union[str, BaseProject]) -> None:
+    def remove_project(self, project: str | BaseProject) -> None:
         """Remove a project from the configuration files."""
         project = self.projects[project] if isinstance(project, str) else project
         Path(self._projects_path, project.engine, f"{project.name}.json").unlink()

--- a/aiida_project/project/venv.py
+++ b/aiida_project/project/venv.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 from pathlib import Path
+from typing import ClassVar
 
 from aiida_project.config import ProjectConfig
 from aiida_project.project.base import BaseProject
@@ -11,12 +12,12 @@ class VenvProject(BaseProject):
 
     _engine = "venv"
 
-    shell_activate_mapping: dict = {
+    shell_activate_mapping: ClassVar[dict[str, str]] = {
         "bash": "activate",
         "zsh": "activate",
         "fish": "activate.fish",
     }
-    shell_deactivate_mapping: dict = {
+    shell_deactivate_mapping: ClassVar[dict[str, str]] = {
         "bash": "deactivate () {",
         "zsh": "deactivate () {",
         "fish": 'function deactivate -d "Exit virtual environment"',

--- a/aiida_project/shell.py
+++ b/aiida_project/shell.py
@@ -1,4 +1,5 @@
 """Functionality to support various shells with `aiida-project`."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 keywords = ["aiida", "workflows"]
 requires-python = ">=3.9"
 dependencies = [
-  "py~=1.11",
   "pydantic~=2.7",
   "pydantic-settings~=2.2",
   "python-dotenv~=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,28 @@ dev = [
 [tool.mypy]
 plugins = ['pydantic.mypy']
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
+# TODO: PLW1510 should be enabled and fixed!
+# See `ruff rule PLW1510`
+ignore = [
+  'PLW2901',  # `for` loop variable overwritten by assignment target
+  'PLW1510',  # `subprocess.run` without explicit `check` argument
+  'PLC0415',  # `import` should be at the top-level of a file
+]
+
+select = [
+  'E',  # pydocstyle
+  'W',  # pydocstyle
+  'F',  # pyflakes
+  'I',  # isort
+  'N',  # pep8-naming
+  'UP',   # pyupgrade
+  'PLC',  # pylint-convention
+  'PLE',  # pylint-error
+  'PLR',  # pylint-refactor
+  'PLW',  # pylint-warning
+  'RUF',  # ruff-specific rules
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ dev = [
   "types-pyyaml~=6.0",
 ]
 
+[dependency-groups]
+dev = [
+    "aiida-project[dev]",
+]
+
 [tool.mypy]
 plugins = ['pydantic.mypy']
 


### PR DESCRIPTION
- Use ruff for both linting and formatting (added ruff config from aiida-core)
- Remove unused `py` dependency (used only in disabled conda support, and also is deprecated)

New version of #31 