### PR TITLE
📦 `typer`: remove `all` extra and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "pydantic~=2.7",
   "pydantic-settings~=2.2",
   "python-dotenv~=1.0",
-  "typer[all]~=0.9",
+  "typer~=0.19.2",
   "pyyaml~=6.0",
   'eval-type-backport; python_version<"3.10"',
   "uv~=0.8.20",


### PR DESCRIPTION
Since v0.12.1, `typer` no longer requires the `all` extra, since it installs `rich` and `shellingham` by default:

https://typer.tiangolo.com/release-notes/#0121

We also bump the version to the latest one. There should be no breaking changes that affect us.