### PR TITLE
Add tab completion to `cda`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ or simply open a new terminal.
 ```
 
 This will also add the `cda` function to your shell startup file, so you can easily switch projects.
-Note that you'll have to source your e.g. `.zshrc` file for this function to be accessible!
+In order to activate tab-completion, you'll have to run
+
+    aiida-project --install-completion
+
+> [!NOTE]
+> You will have to and restart the terminal after running either of these commands, or source the shell config file.
 
 ### `create`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ aiida-project init
 
 Info: For the changes to take effect, run the following command:
 
-    source /Users/mbercx/.zshrc
+    source ~/.aiida_project/init.zsh
 
 or simply open a new terminal.
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ You can then activate the project using the `cda` command described above:
 cda firstproject
 ```
 
+The `cda` command supports tab-completion and lists the available projects.
+
 Next to activating the Python virtual environment, this will also change the directory to the one for the project.
 `aiida-project` automatically sets up a directory structure, which we intend to be made configurable globally:
 

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -20,11 +20,26 @@ _NOT_INITIALISED_MSG = (
 
 
 @app.callback()
-def callback() -> None:
+def callback(ctx: typer.Context) -> None:
     """
     AiiDA project manager: Isolated Python environments tailored to AiiDA
     with separated project directories, configs, and AiiDA profiles.
     """
+    if ctx.invoked_subcommand == "init":
+        return
+
+    from ..config import ProjectConfig
+
+    config = ProjectConfig()
+    if not config.is_initialised():
+        return
+
+    shell = load_shell(config.aiida_project_shell)
+    if shell.is_outdated:
+        print(
+            "⚠️  [bold yellow]Warning:[/] Shell configuration is outdated. "
+            "Run [bold]aiida-project init[/bold] to update."
+        )
 
 
 @app.command()

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import sys
-from datetime import datetime
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Annotated
@@ -53,31 +52,24 @@ def init(shell: ShellType | None = None) -> None:
     config.set_key("aiida_project_shell", shell_str)
     shellz = load_shell(shell_str)
 
-    shellz.config_file.touch(exist_ok=True)
+    is_reinit = shellz.write_config(str(config.model_config["env_file"]))
 
-    if "Created by `aiida-project init`" in shellz.config_file.read_text():
-        print(
-            "[bold blue]Report:[/] There is already an `aiida-project` initialization comment in "
-            f"{shellz.config_file}"
-        )
-        add_init_lines = prompt.Confirm.ask("Do you want still want to add the init lines?")
-    else:
-        add_init_lines = True
+    rc_file = ShellType(shell_str).rc_file
 
-    if add_init_lines:
-        with shellz.config_file.open("a") as handle:
-            handle.write(
-                f"\n# Created by `aiida-project init` on "
-                f"{datetime.now().strftime('%d/%m/%y %H:%M')}\n"
-            )
-            handle.write(shellz.init_lines.format(env_file_path=config.model_config["env_file"]))
+    if rc_file is not None:
+        shellz.ensure_source_line(rc_file)
 
     config.set_key(
         "aiida_venv_dir",
         os.environ.get("WORKON_HOME", config.aiida_venv_dir.as_posix()),
     )
     config.set_key("aiida_project_dir", config.aiida_project_dir.as_posix())
-    print("\n✨🚀 AiiDA-project has been initialised! 🚀✨\n")
+
+    if is_reinit:
+        print("\n🔄 AiiDA-project shell configuration has been updated.\n")
+    else:
+        print("\n✨🚀 AiiDA-project has been initialised! 🚀✨\n")
+
     print("[bold blue]Info:[/] For the changes to take effect, run the following command:")
     print(f"\n    source {shellz.config_file.resolve()}\n")
     print("or simply open a new terminal.")

--- a/aiida_project/commands/main.py
+++ b/aiida_project/commands/main.py
@@ -13,6 +13,11 @@ from ..shell import ShellType, load_shell
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
 
+_NOT_INITIALISED_MSG = (
+    "[bold red]Error:[/bold red] The AiiDA project config has not been initialised.\n"
+    "[bold blue]Info:[/bold blue] Please run `aiida-project init` to get started."
+)
+
 
 @app.callback()
 def callback() -> None:
@@ -96,7 +101,8 @@ def create(  # noqa: PLR0915
     from ..project import ProjectDict
 
     config = ProjectConfig()
-    if config.is_not_initialised():
+    if not config.is_initialised():
+        print(_NOT_INITIALISED_MSG)
         sys.exit(os.EX_CONFIG)
 
     # Guard against user putting an empty string (allowed by typer!)
@@ -187,7 +193,8 @@ def destroy(
     from ..config import ProjectConfig
     from ..project import ProjectDict
 
-    if ProjectConfig().is_not_initialised():
+    if not ProjectConfig().is_initialised():
+        print(_NOT_INITIALISED_MSG)
         sys.exit(os.EX_CONFIG)
 
     project_dict = ProjectDict()
@@ -218,7 +225,7 @@ def list_projects() -> None:
     from ..config import ProjectConfig
     from ..project import ProjectDict
 
-    if ProjectConfig().is_not_initialised():
+    if not ProjectConfig().is_initialised():
         sys.exit(os.EX_CONFIG)
 
     projects = ProjectDict().projects

--- a/aiida_project/config.py
+++ b/aiida_project/config.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from rich import print
 
 DEFAULT_PROJECT_STRUCTURE = {
     "setup": [
@@ -28,13 +27,8 @@ class ProjectConfig(BaseSettings):
         env_file=Path.home() / Path(".aiida_project.env"), env_file_encoding="utf-8"
     )
 
-    def is_not_initialised(self) -> bool:
-        if dotenv.get_key(self.model_config["env_file"], "aiida_project_shell") is None:  # type: ignore[arg-type]
-            print("[bold red]Error:[/bold red] The AiiDA project config has not been initialised.")
-            print("[bold blue]Info:[/bold blue] Please run `aiida-project init` to get started.")
-            return True
-        else:
-            return False
+    def is_initialised(self) -> bool:
+        return dotenv.get_key(self.model_config["env_file"], "aiida_project_shell") is not None  # type: ignore[arg-type]
 
     def set_key(self, key: str, value: Any) -> None:
         dotenv.set_key(self.model_config["env_file"], key, value)  # type: ignore[arg-type]

--- a/aiida_project/data/shell_fields.yaml
+++ b/aiida_project/data/shell_fields.yaml
@@ -7,6 +7,16 @@ bash:
       source "$aiida_venv_dir/$1/bin/activate"
       cd "$aiida_project_dir/$1"
     }}
+    _cda_complete() {{
+      COMPREPLY=()
+      if [[ $COMP_CWORD -eq 1 ]]; then
+        local projects
+        projects=($(find "$aiida_project_dir/.aiida_projects" -type f -name "*.json" \
+          -exec basename {{}} .json \;))
+        COMPREPLY=($(compgen -W "${{projects[*]}}" -- "${{COMP_WORDS[COMP_CWORD]}}"))
+      fi
+    }}
+    complete -F _cda_complete cda
   activate: |
     export AIIDA_PATH={env_file_path}
     eval "$(_VERDI_COMPLETE=bash_source verdi)"
@@ -14,7 +24,20 @@ bash:
     unset AIIDA_PATH
 zsh:
   config_file: .aiida_project/init.zsh
-  init_lines: *bash_init_lines
+  init_lines: |
+    export $(grep -v '^#' {env_file_path} | xargs)
+    cda () {{
+      source "$aiida_venv_dir/$1/bin/activate"
+      cd "$aiida_project_dir/$1"
+    }}
+    _cda_complete() {{
+      local projects
+      projects=($(find "$aiida_project_dir/.aiida_projects" -type f -name "*.json" \
+        -exec basename {{}} .json \;))
+      compadd -- ${{projects[@]}}
+    }}
+    autoload -Uz compinit && compinit -C
+    compdef _cda_complete cda
   activate: |
     export AIIDA_PATH={env_file_path}
     eval "$(_VERDI_COMPLETE=zsh_source verdi)"
@@ -33,6 +56,12 @@ fish:
         cd "$aiida_project_dir/$argv[1]"
     end
     funcsave -q cda
+    function _cda_complete
+        find $aiida_project_dir/.aiida_projects -type f -name "*.json" | while read f
+            basename $f .json
+        end
+    end
+    complete -c cda -f -a "(_cda_complete)"
   activate: |
     set -gx AIIDA_PATH {env_file_path}
     eval (env _VERDI_COMPLETE=fish_source verdi)

--- a/aiida_project/data/shell_fields.yaml
+++ b/aiida_project/data/shell_fields.yaml
@@ -1,5 +1,5 @@
 bash:
-  config_file: .bashrc
+  config_file: .aiida_project/init.bash
   init_lines: &bash_init_lines |
     export $(grep -v '^#' {env_file_path} | xargs)
     cda () {{
@@ -12,7 +12,7 @@ bash:
   deactivate: &bash_deactivate |
     unset AIIDA_PATH
 zsh:
-  config_file: .zshrc
+  config_file: .aiida_project/init.zsh
   init_lines: *bash_init_lines
   activate: |
     export AIIDA_PATH={env_file_path}

--- a/aiida_project/data/shell_fields.yaml
+++ b/aiida_project/data/shell_fields.yaml
@@ -1,3 +1,4 @@
+version: 1
 bash:
   config_file: .aiida_project/init.bash
   init_lines: &bash_init_lines |

--- a/aiida_project/shell.py
+++ b/aiida_project/shell.py
@@ -37,6 +37,8 @@ class Shell(BaseModel):
     """AiiDA-specific lines to add to the environment's activate script."""
     deactivate: str
     """AiiDA-specific lines to add to the environment's deactivate script."""
+    version: int
+    """Shell config version from shell_fields.yaml."""
 
     @field_validator("config_file")
     @classmethod
@@ -52,7 +54,9 @@ class Shell(BaseModel):
         is_reinit = self.config_file.exists()
         self.config_file.parent.mkdir(parents=True, exist_ok=True)
 
-        self.config_file.write_text(self.init_lines.format(env_file_path=env_file_path))
+        self.config_file.write_text(
+            f"# version: {self.version}\n" + self.init_lines.format(env_file_path=env_file_path)
+        )
         return is_reinit
 
     def ensure_source_line(self, rc_file: Path) -> None:
@@ -69,11 +73,26 @@ class Shell(BaseModel):
                     f"{BLOCK_END}\n"
                 )
 
+    def _installed_version(self) -> int:
+        """Read the version from the installed config file."""
+        first_line = self.config_file.read_text().split("\n")[0]
+        try:
+            return int(first_line.removeprefix("# version: "))
+        except ValueError:
+            return 0
+
+    @property
+    def is_outdated(self) -> bool:
+        """Whether the installed shell config is older than the current version."""
+        if not self.config_file.exists():
+            return False
+        return self._installed_version() < self.version
+
 
 def load_shell(shell_str: str) -> Shell:
-    """Load the project class corresponding the engine type."""
+    """Load the shell configuration for the given shell type."""
     from . import data
 
     with (resources.files(data) / "shell_fields.yaml").open("r") as handle:
         specs = yaml.safe_load(handle)
-    return Shell(**specs[shell_str])
+    return Shell(version=specs["version"], **specs[shell_str])

--- a/aiida_project/shell.py
+++ b/aiida_project/shell.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 from importlib import resources
 from pathlib import Path
@@ -9,11 +10,22 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, field_validator
 
+BLOCK_START = "# >>> aiida-project >>>"
+BLOCK_END = "# <<< aiida-project <<<"
+
 
 class ShellType(str, Enum):
     bash = "bash"
     zsh = "zsh"
     fish = "fish"
+
+    @property
+    def rc_file(self) -> Path | None:
+        """Absolute path to the shell's rc file, or None if not applicable."""
+        return {
+            ShellType.bash: Path.home() / ".bashrc",
+            ShellType.zsh: Path.home() / ".zshrc",
+        }.get(self)
 
 
 class Shell(BaseModel):
@@ -31,6 +43,31 @@ class Shell(BaseModel):
     def resolve_config_file(cls, value: Path) -> Path:
         """Resolve the shell configuration file."""
         return Path.home() / value
+
+    def write_config(self, env_file_path: str | Path) -> bool:
+        """Write init lines to the dedicated config file.
+
+        Returns True if this is a re-init (file already existed).
+        """
+        is_reinit = self.config_file.exists()
+        self.config_file.parent.mkdir(parents=True, exist_ok=True)
+
+        self.config_file.write_text(self.init_lines.format(env_file_path=env_file_path))
+        return is_reinit
+
+    def ensure_source_line(self, rc_file: Path) -> None:
+        """Add source line block to rc_file if not already present."""
+        rc_file.touch(exist_ok=True)
+
+        if BLOCK_START not in rc_file.read_text():
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            with rc_file.open("a") as handle:
+                handle.write(
+                    f"\n{BLOCK_START}\n"
+                    f"# Configured on {timestamp}\n"
+                    f"source {self.config_file}\n"
+                    f"{BLOCK_END}\n"
+                )
 
 
 def load_shell(shell_str: str) -> Shell:


### PR DESCRIPTION
Supersedes #14 

<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/4e0e9446-d5dd-457e-b181-91d4dd3518b3" />

@t-reents originally I was planning to update your PR, but I noticed that you opened it from your fork's `main` branch. I felt awkward about force pushing your `main`, so opened a new PR, hope that's ok! I added you as a co-author in the relevant commits.

Besides adding tab-completion, I realised that we need some way to be able to update these shell scripts without the user having to remove and add them every time, that seemed really fragile and annoying. So in d648aafeaa8850a98fcbf707e251f9e45f3c1297 makes sure we have a separate source file for each shell. But then how would users know to run init? They would need to know something changed. To track that, you need a version, hence 073cc15b5228c6d9ecf15261c776a6cc3cc6aa5d. 8353c59bbbf5b95156df1305cbc9a244c713e6e6 was an improvement triggered while working on that.

So I went down a little rabbit hole. I hope it's not over-engineered. But frankly I think we're going to want to change these source files over time (also because I'm not an expert on shell scripting: the `cda` changes were partially vibe-coded for bash and zsh). I think this infrastructure will come in handy, and it doesn't add _that_ much code to maintain.

I also think we're writing too many files to `$HOME`. So I would also move all our config files + environments into `.aiida_project`. But will think about / implement that after this PR is merged. Hopefully then we can limit the pain of these migrations to a single release.